### PR TITLE
Fix script not working on firefox

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -13,6 +13,7 @@
     "https://garlic-bread.reddit.com/embed*",
     "https://place.equestria.dev/embed*"
   ],
+  "inject-into": "content",
   "downloadURL": "http://ponyplace-cdn.ferrictorus.com/loader.user.js",
   "updateURL": "http://ponyplace-cdn.ferrictorus.com/loader.user.js",
   "connect": [


### PR DESCRIPTION
It only work with ViolentMonkey. Also tested on chromium.
GreaseMonkey+Firefox confirmed not to work.

Note that directly loading the ``minimap.user.js`` worked fine.

Fix https://github.com/r-ainbowroad/2023-minimap/issues/11